### PR TITLE
Fix crafting grid display in Chrome

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -451,7 +451,8 @@ footer a {
 }
 
 .grid {
-  width: 165px;
+  padding: 12px;
+  width: 145px;
 }
 
 .grid h5 {


### PR DESCRIPTION
The grid displays fine in Firefox, but in Chrome rows are 4 boxes wide. This fixes crafting grid display in Chrome while keeping it virtually unchanged in Firefox.

Chrome before:
![image](https://user-images.githubusercontent.com/11380394/76158333-8775c200-60da-11ea-9ceb-5ddcb5674883.png)

Chrome after:
![image](https://user-images.githubusercontent.com/11380394/76158337-92305700-60da-11ea-848a-fba838b25290.png)

Firefox before:
![image](https://user-images.githubusercontent.com/11380394/76158341-9a889200-60da-11ea-847c-f40b1dbdb873.png)

Firefox after:
![image](https://user-images.githubusercontent.com/11380394/76158345-a1afa000-60da-11ea-858d-37763cb63f4e.png)

