### PR TITLE
Rename rule 2.1 for consistency with text

### DIFF
--- a/src/rules.html
+++ b/src/rules.html
@@ -101,7 +101,7 @@
             <h2>2. Behavior and chat</h2>
             <ul>
                 <li>
-                    <b>2.1 Teleport traps</b><br />
+                    <b>2.1 Traps</b><br />
                     The act of tricking players into teleporting to a specific location or person just to kill or trap them is not allowed. This used to be allowed but a lot of players abused it to the degree players voted to forbid it.<br>
                     <br/>
                     Normal traps that don't involve players blindly teleporting into them are allowed however, as long as the player doesn't get stuck for a longer period of time.


### PR DESCRIPTION
Rename rule 2.1 from "Teleport traps" to "Traps" as it prohibits both
teleport traps and (some) non-teleport traps.