### PR TITLE
Update to rule 3.3

### DIFF
--- a/src/rules.html
+++ b/src/rules.html
@@ -180,10 +180,17 @@
       </li>
       <li id="3.3">
         <b>3.3	Town claims</b><br/>
-        Creating claim arms extending from towns is not allowed. These are protrusions which are often used to block the expansion of other towns or just artificially expand the area a town controls without the need to claim all of it.<br>
-        Claim arms that follow a certain strip of land surrounded by water like a peninsula are allowed however as no one would be claiming around it anyway.<br>
+        Creating claim arms extending from towns is not allowed.
+        These are protrusions which are often used to block the expansion of other towns or just artificially expand the area a town controls without the need to claim all of it.<br>
+        Claim arms that follow a certain strip of land surrounded by water like a peninsula or series of islands are allowed however as no one would be claiming around it anyway.<br>
         <br>
         Towns are not allowed to have areas of unclaimed chunks inside of their borders as this can substantially increase the size of a town without them actually having to increase their claim limit legitimately.<br>
+        <br>
+        Towns which are clearly created for no other reason than to block an existing town will also be removed.
+        This applies to situations such as creating a town in the sea on the border of another town as there would be no reason to claim there other than to block the existing one.
+        It does not apply to someone just placing a town close to an existing one if there is not much room to claim in the area.
+        <br>
+        Staff will routinely remove hollow claims as we have automated tools for that, the other types of claim blocking will only be removed when reported by the mayor of a blocked town.
       </li>
       <li id="3.4">
         <b>3.4  Stealing specific blocks</b><br/>

--- a/src/rules.html
+++ b/src/rules.html
@@ -180,9 +180,10 @@
       </li>
       <li id="3.3">
         <b>3.3	Town claims</b><br/>
-        Towns are not allowed to have areas of unclaimed chunks inside of their borders as this can substantially increase the size of a town without them actually having to increase their claim limit legitimately.<br>
+        Creating claim arms extending from towns is not allowed. These are protrusions which are often used to block the expansion of other towns or just artificially expand the area a town controls without the need to claim all of it.<br>
+        Claim arms that follow a certain strip of land surrounded by water like a peninsula are allowed however as no one would be claiming around it anyway.<br>
         <br>
-        Surrounding other towns with claims is also not allowed, about 3/4 of the town has to be surrounded for it to count as illegal. The only exception to this is when a town is created in an area where it is already surrounded. 
+        Towns are not allowed to have areas of unclaimed chunks inside of their borders as this can substantially increase the size of a town without them actually having to increase their claim limit legitimately.<br>
       </li>
       <li id="3.4">
         <b>3.4  Stealing specific blocks</b><br/>

--- a/src/rules.html
+++ b/src/rules.html
@@ -187,7 +187,7 @@
         Towns are not allowed to have areas of unclaimed chunks inside of their borders as this can substantially increase the size of a town without them actually having to increase their claim limit legitimately.<br>
         <br>
         Towns which are clearly created for no other reason than to block an existing town will also be removed.
-        This applies to situations such as creating a town in the sea on the border of another town as there would be no reason to claim there other than to block the existing one.
+        This applies to situations such as creating a town in the sea on the border of another town as there would be no reason to claim there other than to block the existing town.
         It does not apply to someone just placing a town close to an existing one if there is not much room to claim in the area.
         <br>
         Staff will routinely remove hollow claims as we have automated tools for that, the other types of claim blocking will only be removed when reported by the mayor of a blocked town.


### PR DESCRIPTION
```html
      <li id="3.3">
        <b>3.3	Town claims</b><br/>
        Creating claim arms extending from towns is not allowed.
        These are protrusions which are often used to block the expansion of other towns or just artificially expand the area a town controls without the need to claim all of it.<br>
        Claim arms that follow a certain strip of land surrounded by water like a peninsula or series of islands are allowed however as no one would be claiming around it anyway.<br>
        <br>
        Towns are not allowed to have areas of unclaimed chunks inside of their borders as this can substantially increase the size of a town without them actually having to increase their claim limit legitimately.<br>
        <br>
        Towns which are clearly created for no other reason than to block an existing town will also be removed.
        This applies to situations such as creating a town in the sea on the border of another town as there would be no reason to claim there other than to block the existing one.
        It does not apply to someone just placing a town close to an existing one if there is not much room to claim in the area.
        <br>
        Staff will routinely remove hollow claims as we have automated tools for that, the other types of claim blocking will only be removed when reported by the mayor of a blocked town.
      </li>
```